### PR TITLE
Lua 5.1 5.2 support, compiler warning fixes

### DIFF
--- a/builders/cmake/cmake_find_modules/Find_lua.cmake
+++ b/builders/cmake/cmake_find_modules/Find_lua.cmake
@@ -4,6 +4,8 @@ FIND_PATH(LUA_INCLUDE_PATH_
 		lualib.h
 	PATHS
 		/usr/include
+		/usr/include/lua5.1
+		/usr/include/lua5.2
 		/usr/local/include
 		/usr/local/include/lua51
 		/sw/include
@@ -13,9 +15,12 @@ FIND_PATH(LUA_INCLUDE_PATH_
 FIND_LIBRARY(LUA_LIBRARY_PATH_
 	NAMES
 		lua
+		lua5.1
+		lua5.2
 	PATHS
 		/usr/lib64
 		/usr/lib
+		/usr/lib/x86_64-linux-gnu
 		/usr/local/lib64
 		/usr/local/lib
 		/usr/local/lib64/lua51

--- a/sources/applications/applestreamingclient/src/protocols/aes/inboundaesprotocol.cpp
+++ b/sources/applications/applestreamingclient/src/protocols/aes/inboundaesprotocol.cpp
@@ -109,9 +109,9 @@ bool InboundAESProtocol::SignalInputData(IOBuffer &buffer) {
 	_totalDecrypted += decryptedSize;
 
 	//6. Decrypt leftovers
-	bool transferCompleted = false;
+	//bool transferCompleted = false;
 	if (((HTTPBufferProtocol *) GetFarProtocol())->TransferCompleted()) {
-		transferCompleted = true;
+		//transferCompleted = true;
 		EVP_DecryptFinal_ex(&_decContex,
 				pTempData + decryptedSize,
 				&decryptedFinalSize);


### PR DESCRIPTION
Support lua 5.1, 5.2 and more recent 64-bit library locations
Fix compiler warning: remove unused variable